### PR TITLE
Fixed lib64 not being used.

### DIFF
--- a/bin/cat-c
+++ b/bin/cat-c
@@ -54,7 +54,13 @@ if test "$pass_cmd" == "" ; then
     else
       suffixToUse="so" ;
     fi
-    pass_cmd="$installdir/../lib/CAT.${suffixToUse}";
+
+    # Figure out the lib prefix.
+    libprefix="lib"
+    if test -d "$installdir/../lib64"; then
+      libprefix="lib64"
+    fi
+    pass_cmd="$installdir/../$libprefix/CAT.${suffixToUse}";
   fi
 fi
 if test "$lib_dir" != "" ; then


### PR DESCRIPTION
As described in #2 `Fedora36` uses `lib64` instead of `lib` for libraries. When `cmake` builds everything, the libraries get installed in `~/CAT/lib64/CAT.so` so `cat-c` fails to find it in `~/CAT/lib/CAT.so`.

### Proposal

The proposal is to let `cat-c` `test -d` for `lib64` and if that succeeds, use `lib64` instead of `lib`. `lib` should be a fallback mechanism since modern operating systems use `lib64` for `x64`-built SOs.

#### Reasoning

`lib64` seems to have completely replaced `lib` on `x64` modern distros and I see no reason why `cat-c` shouldn't use it too.

### Validation

Validated by running `cat-c` against a source file on `f36`.