### PR TITLE
Implemented run_me.sh support for CLI flags to CMAKE

### DIFF
--- a/run_me.sh
+++ b/run_me.sh
@@ -12,7 +12,7 @@ rm -rf build/ ;
 # Build
 mkdir build ; 
 cd build ; 
-${CMAKE} -DCMAKE_INSTALL_PREFIX="~/CAT" -DCMAKE_BUILD_TYPE=Debug ../ ; 
+${CMAKE} -DCMAKE_INSTALL_PREFIX="~/CAT" -DCMAKE_BUILD_TYPE=Debug $@ ../ ; 
 make ;
 make install ;
 cd ../ 


### PR DESCRIPTION
## Proposal

I propose that `run_me.sh` passes its CLI arguments down to CMAKE, enabling customization of the CMAKE build via the CLI.

### Example

This solution enables users to run something like:
```bash
./run_me.sh -D CMAKE_CXX_FLAGS='-DMY_FLAG=true ${CMAKE_CXX_FLAGS}'
```
which is a potential solution for #4 

### Potential Problems

* This is not the cleanest possible solution for #4, since CMAKE does not directly pass it's arguments down to `clang`. A better solution would possibly be to have a flag `--debug-mode` to `run_me.sh` which would always expose a `-DDEBUG_MODE=true` to the compiler. My opinion is that it would even be better if users could safely use the `CMAKE`-provided debug flag while the grading tests would be built `RelWithDebInfo`, still preserving the debug info.
* It is possible that users unfamiliar with `bash` will end up running the aforementioned command like:
```bash
./run_me.sh -D CMAKE_CXX_FLAGS="-DMY_FLAG=true ${CMAKE_CXX_FLAGS}"
```
which will cause shell expansion to happen, evaluating to
```bash
./run_me.sh -D CMAKE_CXX_FLAGS="-DMY_FLAG=true "
```
which will override `CMAKE_CXX_FLAGS` to something potentially undesirable and confusing.